### PR TITLE
updating release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,8 +1,13 @@
 # Configuration for release-drafter/release-drafter
 # This file must live in the default branch at: .github/release-drafter.yml
 
-name-template: "v$RESOLVED_VERSION"
-tag-template: "v$RESOLVED_VERSION"
+# This repo uses CalVer-style tags (e.g. 25.12.2.beta).
+# Release Drafter's $RESOLVED_VERSION is SemVer-oriented and will fall back to v0.1.0
+# when it can't infer a SemVer version from tags.
+#
+# We keep the draft title/tag generic; the actual release tag should be chosen when
+# publishing the GitHub Release.
+name-template: "Release Notes (Draft)"
 
 categories:
   - title: "Breaking Changes"


### PR DESCRIPTION
**Motivation and Rationale**

The previous release drafter configuration assumed a SemVer tagging scheme, which does not align with our use of CalVer-style tags. This mismatch caused auto-generated draft releases to have incorrect or placeholder versions (e.g., v0.1.0), potentially leading to confusion and additional manual steps during release publishing.

**Why this improves the project**

By updating the `name-template` to a generic "Release Notes (Draft)", we avoid confusion and ensure that the draft release accurately reflects its purpose, regardless of our versioning scheme. This allows maintainers to manually specify the correct CalVer tag at release time, streamlining the release process and reducing errors.

This change clarifies the workflow for our CalVer-based project, making releases more predictable and easier to manage.