### PR TITLE
working on documentation flow bugs

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -53,6 +53,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+      - name: Fetch gh-pages branch (avoid non-fast-forward)
+        run: |
+          git fetch origin gh-pages:gh-pages || true
+
       - name: Prepare documentation files
         run: |
           python3 scripts/update_docs.py

--- a/scripts/deploy_docs.py
+++ b/scripts/deploy_docs.py
@@ -81,6 +81,15 @@ def deploy_documentation(
     project_root = Path(__file__).resolve().parent.parent
     os.chdir(project_root)
 
+    # Ensure the local repo has the latest docs branch so mike can fast-forward push.
+    # This avoids failures like: "gh-pages (non-fast-forward)" in CI re-runs.
+    if push and branch:
+        try:
+            run_command(["git", "fetch", "origin", f"{branch}:{branch}"])
+        except subprocess.CalledProcessError:
+            # If the branch doesn't exist yet (first deploy), mike will create it.
+            pass
+
     cmd: list[str] = ["mike", "deploy"]
 
     if branch:


### PR DESCRIPTION
### Motivation

There have been recurring issues with documentation deployment failing due to non-fast-forward errors on the `gh-pages` branch, especially during CI re-runs or when the branch is updated externally. These errors disrupt the documentation publishing workflow and can cause confusion or delays.

### Why this improves the project

This PR updates the documentation deployment workflow to ensure the latest `gh-pages` branch is fetched before attempting to push new docs. By explicitly fetching the branch both in the CI workflow and in the deploy script, we minimize the risk of non-fast-forward errors and make the deployment process more robust and predictable. This leads to fewer failed deployments and a smoother documentation update experience for all contributors.