### PR TITLE
deploy docs

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -88,6 +88,11 @@ jobs:
 
           mike set-default stable --branch "$DOCS_BRANCH" --push
 
+      - name: Clean working tree before gh-pages checkout
+        run: |
+          git reset --hard
+          git clean -fd
+
       - name: Checkout gh-pages branch content
         run: |
           git fetch origin gh-pages


### PR DESCRIPTION
**Motivation**

The deployment workflow for documentation previously did not ensure a clean working tree before checking out the `gh-pages` branch. This could lead to conflicts or leftover files from previous steps interfering with the deployment process.

**Why this improves the project**

By explicitly cleaning the working tree (`git reset --hard` and `git clean -fd`) before checking out the `gh-pages` branch, we ensure that only the relevant documentation files are present. This reduces the risk of deployment errors, prevents stray files from being published, and makes the documentation deployment process more robust and reliable.