### PR TITLE
Documentation Fix

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,7 +1,7 @@
 name: Deploy Documentation
 
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
       version:
         description: "Docs version label for mike (e.g. 26.1.2b1)"

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -32,37 +32,40 @@ jobs:
         with:
           packages-dir: dist
 
-  trigger-docs:
-    name: Trigger documentation deployment
+  prepare-docs-inputs:
+    name: Prepare docs deployment inputs
     runs-on: ubuntu-latest
-    needs: deploy  # Wait for PyPI deployment to complete
-    permissions:
-      actions: write
-      contents: read
+    outputs:
+      version: ${{ steps.docs-inputs.outputs.version }}
+      checkout_ref: ${{ steps.docs-inputs.outputs.checkout_ref }}
+      aliases: ${{ steps.docs-inputs.outputs.aliases }}
     steps:
-      - name: Dispatch docs workflow on main
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const rawTag = context.payload.release?.tag_name;
-            if (!rawTag) {
-              core.setFailed('Missing release.tag_name; cannot dispatch docs build.');
-              return;
-            }
+      - name: Compute docs inputs from release tag
+        id: docs-inputs
+        run: |
+          raw_tag="${{ github.event.release.tag_name }}"
+          if [ -z "$raw_tag" ]; then
+            echo "Missing release.tag_name; cannot continue."
+            exit 1
+          fi
 
-            // Strip optional v-prefix for mike version label.
-            const version = rawTag.startsWith('v') ? rawTag.slice(1) : rawTag;
+          version="${raw_tag#v}"
 
-            await github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: 'deploy-docs.yml',
-              ref: 'main',
-              inputs: {
-                version,
-                checkout_ref: rawTag,
-                aliases: 'latest stable',
-              },
-            });
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "checkout_ref=$raw_tag" >> "$GITHUB_OUTPUT"
+          echo "aliases=latest stable" >> "$GITHUB_OUTPUT"
 
-            core.info(`Dispatched deploy-docs.yml on ref=main (checkout_ref=${rawTag}, version=${version})`);
+  deploy-docs:
+    name: Deploy documentation after PyPI publish
+    needs:
+      - deploy
+      - prepare-docs-inputs
+    uses: ./.github/workflows/deploy-docs.yml
+    with:
+      version: ${{ needs.prepare-docs-inputs.outputs.version }}
+      checkout_ref: ${{ needs.prepare-docs-inputs.outputs.checkout_ref }}
+      aliases: ${{ needs.prepare-docs-inputs.outputs.aliases }}
+    permissions:
+      contents: write
+      pages: write
+      id-token: write

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,7 +94,7 @@ plugins:
             show_submodules: True
   - mike:
       # Version management configuration
-      alias_type: symlink
+      alias_type: redirect
       redirect_template: null
       deploy_prefix: ''
       canonical_version: null


### PR DESCRIPTION
**Motivation and Why This Improves the Project**

This pull request refactors the documentation deployment workflow to improve maintainability and reliability:

- **Switches from `workflow_dispatch` to `workflow_call`** in `.github/workflows/deploy-docs.yml`, enabling the docs deployment workflow to be triggered with custom inputs from other workflows. This makes the process more modular and reusable.
- **Splits and clarifies the docs deployment trigger in `pythonpublish.yml`**, introducing a dedicated job to compute and pass inputs to the documentation deployment workflow. This makes the workflow easier to understand and maintain, and avoids duplicating logic.
- **Switches the mike plugin's alias type** in `mkdocs.yml` from `symlink` to `redirect`, improving compatibility with hosting platforms (like GitHub Pages) that do not support symlinks. This ensures documentation aliases work reliably for all users.

Overall, these changes make the documentation deployment process more robust, easier to maintain, and compatible with a broader range of hosting scenarios.